### PR TITLE
`manifold.markets/api` -> `api.manifold.markets`

### DIFF
--- a/R/manifold_api.R
+++ b/R/manifold_api.R
@@ -27,7 +27,7 @@
 
 manifold_api <- function(endpoint, request_type = c("GET", "POST"), key = NULL, params_list = NULL) {
 
-  url <- paste0("https://manifold.markets/api", endpoint)
+  url <- paste0("https://api.manifold.markets", endpoint)
   match.arg(request_type)
 
   # fix empty parameter list


### PR DESCRIPTION
The new one is better, the old one is gonna go away.